### PR TITLE
Fix gist contained

### DIFF
--- a/prefix.c
+++ b/prefix.c
@@ -1024,7 +1024,11 @@ bool pr_consistent(StrategyNumber strategy,
       return pr_contains(key, query, true);
 
     case 2:
-      return pr_contains(query, key, true);
+      if ( is_leaf ) {
+        return pr_contains(query, key, true);
+      } else {
+	return pr_overlaps(query, key);
+      }
 
     case 3:
       if( is_leaf ) {


### PR DESCRIPTION
```
create table tst (
  pref prefix_range
);

insert into tst
select trim(to_char(i, '00000')) from generate_series(1, 99999) as i;

select count(*)
from tst
where pref <@ '55';

create index tst_ix on tst using gist ( pref );

set enable_seqscan = off;

select count(*)
from tst
where pref <@ '55';
```
